### PR TITLE
feat: add v2 player endpoints with detailed stats and per-round data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,6 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc \
-    && rm -rf /var/lib/apt/lists/*
-
 # Copy requirements first for better caching
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -4,25 +4,163 @@ Flask-based API for Scrabble tournament data, compatible with cross-tables.com A
 
 ## Endpoints
 
-- `GET /player.php?player={id}` - Get basic player info
-- `GET /player.php?player={id}&results=1` - Get player info with tournament history
-- `GET /players.php?playerlist={id1},{id2},...` - Get multiple players (max 50)
-- `GET /players.php?search={name}` - Search players by name
-- `GET /players.php?idsonly=1` - Get all player IDs and names (limit 200)
-- `GET /players.php?search={name}&idsonly=1` - Search players (IDs only)
-- `GET /headtohead.php?players={id1}+{id2}+...` - Get head-to-head games
+### v1 (Legacy — maintained for existing clients)
+
+All v1 endpoints use `.php` extension paths for cross-tables compatibility.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/player.php?player={id}` | Get basic player info |
+| GET | `/player.php?player={id}&results=1` | Player info with tournament history |
+| GET | `/players.php?p={id1}+{id2}+...` | Get multiple players by ID (max 50) |
+| GET | `/players.php?search={name}` | Search players by name |
+| GET | `/players.php?idsonly=1` | Get all player IDs and names |
+| GET | `/players.php?search={name}&idsonly=1` | Search players (IDs only) |
+| GET | `/headtohead.php?players={id1}+{id2}+...` | Head-to-head games between players |
+| GET | `/health` | Health check |
+
+### v2 (Clean paths with enhanced data)
+
+New endpoints with detailed player statistics and per-round tournament breakdowns.
+
+#### Player Profile
+
+```
+GET /v2/player/{player_id}
+```
+
+Returns a player's profile, detailed career statistics, and tournament history.
+
+**Response shape:**
+
+```json
+{
+  "playerid": 3039,
+  "name": "Zachary Dang",
+  "country": "USA",
+  "cswrating": 1764,
+  "photourl": "https://legacy.wespa.org/aardvark/icons/zacharydang.jpg",
+  "stats": {
+    "gamesPlayed": 68,
+    "wins": 33,
+    "losses": 34,
+    "draws": 1,
+    "byes": 0,
+    "winPercentage": 48.53,
+    "averageScore": 423.22,
+    "averageAgainst": 414.90,
+    "highGame": 588,
+    "highGameOpponent": "Ian Coventry",
+    "lowGame": 291,
+    "lowGameOpponent": "Winter",
+    "biggestWin": 287,
+    "biggestWinOpponent": "Gary Oliver",
+    "highLoss": 458,
+    "highLossOpponent": "Victoria Kingham",
+    "lowWin": 373,
+    "lowWinOpponent": "Winter",
+    "gamesUnder300": 2,
+    "games300to399": 23,
+    "games400to499": 33,
+    "games500to599": 10,
+    "games600plus": 0
+  },
+  "tournaments": [
+    {
+      "tourneyid": 52540,
+      "name": "UK Open - Final Fling",
+      "date": "2026-01-10",
+      "division": "A",
+      "wins": 6,
+      "losses": 9,
+      "draws": 0,
+      "spread": -274,
+      "place": 15,
+      "endRating": 1691,
+      "ratingChange": -73,
+      "startDeviation": 67,
+      "endDeviation": 42
+    }
+  ]
+}
+```
+
+#### Tournament Round Details
+
+```
+GET /v2/player/{player_id}/tournaments/{tourney_id}
+```
+
+Returns per-round results for a player at a specific tournament.
+
+**Response shape:**
+
+```json
+{
+  "playerid": 3039,
+  "tourneyid": 52540,
+  "name": "UK Open - Final Fling",
+  "date": "2026-01-10",
+  "division": "A",
+  "rounds": [
+    {
+      "round": 1,
+      "opponent_name": "Nuala O'Rourke",
+      "opponent_id": 61,
+      "opponent_rating": 1704,
+      "result": "L",
+      "score_for": 360,
+      "score_against": 388,
+      "player_rating_at_time": 1764
+    }
+  ]
+}
+```
+
+- `cswrating` is the player's `end_rating` from their most recent tournament, or falls back to the `players.rating` column if no tournaments exist.
+- `endRating` / `ratingChange` / `startDeviation` / `endDeviation` in each tournament entry reflect the rating and rating deviation at the end of that tournament.
+- Result values: `W` (win), `L` (loss), `D` (draw), `B` (bye).
+
+## Project Structure
+
+```
+wespa-api/
+├── app.py                   # Flask application entry point
+├── config.py                # Configuration (DB, cache, rate limiting)
+├── api/
+│   ├── __init__.py
+│   ├── player.py            # v1 player endpoint (/player.php)
+│   ├── players.py           # v1 players endpoint (/players.php)
+│   ├── headtohead.py        # v1 head-to-head endpoint (/headtohead.php)
+│   └── player_v2.py         # v2 player endpoints (/v2/player/...)
+├── services/
+│   ├── __init__.py
+│   ├── db.py                # Database connection pool and helpers
+│   ├── player_queries.py    # v1 player data queries
+│   ├── headtohead_queries.py
+│   └── player_v2_queries.py # v2 player stats and round queries
+├── models/
+│   ├── __init__.py
+│   └── schemas.py           # Data transfer objects (v1 and v2)
+└── requirements.txt
+```
 
 ## Deployment
 
 ### Environment Variables
-- `DB_HOST` - Database host
-- `DB_PORT` - Database port (default: 3306)
-- `DB_USER` - Database user
-- `DB_PASSWORD` - Database password
-- `DB_NAME` - Database name
-- `RATELIMIT_DEFAULT` - Rate limit (default: "100 per minute")
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DB_HOST` | Database host | `localhost` |
+| `DB_PORT` | Database port | `3306` |
+| `DB_USER` | Database user | `root` |
+| `DB_PASSWORD` | Database password | (empty) |
+| `DB_NAME` | Database name | `wespa` |
+| `RATELIMIT_DEFAULT` | API rate limit | `100 per minute` |
 
 ### Docker Build
+
 ```bash
 docker build -t wespa-api .
 docker run -p 8080:8080 --env-file .env wespa-api
+```

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,1 +1,1 @@
-# This file makes the api directory a Python package
+from api import player, players, headtohead, player_v2

--- a/api/player_v2.py
+++ b/api/player_v2.py
@@ -1,0 +1,83 @@
+from flask import Blueprint, request, jsonify
+import logging
+
+from services.player_v2_queries import (
+    get_basic_player_v2,
+    get_player_stats_v2,
+    get_tournament_list_v2,
+    get_tournament_rounds_v2,
+)
+from models.schemas import (
+    PlayerResponseV2,
+    PlayerStatsV2,
+    TournamentListItemV2,
+    TournamentResultDetailV2,
+    TournamentRoundResult,
+)
+
+logger = logging.getLogger(__name__)
+bp = Blueprint('player_v2', __name__)
+
+
+@bp.route('/v2/player/<int:player_id>')
+def get_player_v2(player_id: int):
+    """Get player info with detailed stats and tournament list (v2)."""
+    try:
+        basic = get_basic_player_v2(player_id)
+        if not basic:
+            return jsonify({'error': 'Player not found'}), 404
+
+        stats_data = get_player_stats_v2(player_id)
+        stats = PlayerStatsV2(stats_data) if stats_data else PlayerStatsV2({})
+
+        tournament_rows = get_tournament_list_v2(player_id)
+
+        response = PlayerResponseV2({
+            'playerid': basic['playerid'],
+            'name': basic['name'],
+            'country': basic['country'],
+            'cswrating': basic['cswrating'],
+            'photourl': basic['photourl'],
+        })
+        response.stats = stats
+        response.tournaments = [TournamentListItemV2(r) for r in tournament_rows]
+
+        return jsonify(response.to_dict())
+
+    except Exception as e:
+        logger.error(f"Error fetching v2 player {player_id}: {e}")
+        return jsonify({'error': 'Internal server error'}), 500
+
+
+@bp.route('/v2/player/<int:player_id>/tournaments/<int:tourney_id>')
+def get_player_tournament_detail(player_id: int, tourney_id: int):
+    """Get per-round details for a player at a specific tournament."""
+    try:
+        # Validate player exists
+        basic = get_basic_player_v2(player_id)
+        if not basic:
+            return jsonify({'error': 'Player not found'}), 404
+
+        rows = get_tournament_rounds_v2(player_id, tourney_id)
+        if not rows:
+            return jsonify({'error': 'Tournament result not found'}), 404
+
+        # Build the tournament detail response
+        # Use the first row for tournament-level info (name, date, division)
+        detail = TournamentResultDetailV2({
+            'playerid': player_id,
+            'tourneyid': tourney_id,
+            'name': rows[0].get('tournament_name', ''),
+            'date': rows[0].get('tournament_date'),
+            'division': rows[0].get('division_name'),
+        })
+        detail.rounds = [TournamentRoundResult(r) for r in rows]
+
+        return jsonify(detail.to_dict())
+
+    except Exception as e:
+        logger.error(
+            f"Error fetching tournament detail for player {player_id}, "
+            f"tourney {tourney_id}: {e}"
+        )
+        return jsonify({'error': 'Internal server error'}), 500

--- a/app.py
+++ b/app.py
@@ -40,10 +40,11 @@ limiter = Limiter(
 )
 
 # Register blueprints
-from api import player, players, headtohead
+from api import player, players, headtohead, player_v2
 app.register_blueprint(player.bp)
 app.register_blueprint(players.bp)
 app.register_blueprint(headtohead.bp)
+app.register_blueprint(player_v2.bp)
 
 @app.route('/health')
 @cache.cached(timeout=60)

--- a/models/schemas.py
+++ b/models/schemas.py
@@ -1,4 +1,6 @@
 from typing import Optional, List, Dict, Any
+from datetime import date
+
 
 class TournamentResult:
     def __init__(self, data: Dict[str, Any]):
@@ -15,7 +17,7 @@ class TournamentResult:
         self.ratingchange = data.get('ratingchange')
         self.points = data.get('points')
         self.averagepoints = data.get('averagepoints')
-    
+
     def to_dict(self):
         return {
             'tourneyid': self.tourneyid,
@@ -32,6 +34,7 @@ class TournamentResult:
             'points': self.points,
             'averagepoints': self.averagepoints
         }
+
 
 class CrossTablesPlayer:
     def __init__(self, data: Dict[str, Any]):
@@ -53,7 +56,7 @@ class CrossTablesPlayer:
         self.averageScore = data.get('average_score')
         self.opponentAverageScore = data.get('opponent_average_score')
         self.results = []
-    
+
     def to_dict(self, include_results=False):
         result = {
             'playerid': self.playerid,
@@ -71,7 +74,7 @@ class CrossTablesPlayer:
             'state': self.state,
             'country': self.country
         }
-        
+
         if include_results:
             result.update({
                 'tournamentCount': self.tournamentCount,
@@ -79,8 +82,9 @@ class CrossTablesPlayer:
                 'opponentAverageScore': float(self.opponentAverageScore) if self.opponentAverageScore else None,
                 'results': [r.to_dict() for r in self.results]
             })
-        
+
         return result
+
 
 class HeadToHeadGame:
     def __init__(self, data: Dict[str, Any]):
@@ -104,7 +108,7 @@ class HeadToHeadGame:
             'position': data.get('player2_position')
         }
         self.annotated = data.get('annotated')
-    
+
     def to_dict(self):
         return {
             'gameid': self.gameid,
@@ -113,4 +117,182 @@ class HeadToHeadGame:
             'player1': self.player1,
             'player2': self.player2,
             'annotated': self.annotated
+        }
+
+
+class HeadToHeadResult:
+    """Result row from a head-to-head game in its raw form."""
+    def __init__(self, data: Dict[str, Any]):
+        self.gameid = data.get('gameid')
+        self.date = data.get('date')
+        self.tourneyname = data.get('tourneyname')
+        self.player1_id = data.get('player1_id')
+        self.player1_name = data.get('player1_name')
+        self.player1_score = data.get('player1_score')
+        self.player2_id = data.get('player2_id')
+        self.player2_name = data.get('player2_name')
+        self.player2_score = data.get('player2_score')
+
+
+class PlayerStatsV2:
+    """Detailed aggregated stats for a player's career."""
+
+    def __init__(self, data: Dict[str, Any]):
+        self.gamesPlayed = data.get('gamesPlayed', 0)
+        self.wins = data.get('wins', 0)
+        self.losses = data.get('losses', 0)
+        self.draws = data.get('draws', 0)
+        self.byes = data.get('byes', 0)
+        self.winPercentage = data.get('winPercentage', 0.0)
+        self.averageScore = data.get('averageScore', 0.0)
+        self.averageAgainst = data.get('averageAgainst', 0.0)
+        self.highGame = data.get('highGame')
+        self.highGameOpponent = data.get('highGameOpponent')
+        self.lowGame = data.get('lowGame')
+        self.lowGameOpponent = data.get('lowGameOpponent')
+        self.biggestWin = data.get('biggestWin')
+        self.biggestWinOpponent = data.get('biggestWinOpponent')
+        self.highLoss = data.get('highLoss')
+        self.highLossOpponent = data.get('highLossOpponent')
+        self.lowWin = data.get('lowWin')
+        self.lowWinOpponent = data.get('lowWinOpponent')
+        self.gamesUnder300 = data.get('gamesUnder300', 0)
+        self.games300to399 = data.get('games300to399', 0)
+        self.games400to499 = data.get('games400to499', 0)
+        self.games500to599 = data.get('games500to599', 0)
+        self.games600plus = data.get('games600plus', 0)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'gamesPlayed': self.gamesPlayed,
+            'wins': self.wins,
+            'losses': self.losses,
+            'draws': self.draws,
+            'byes': self.byes,
+            'winPercentage': round(self.winPercentage, 2),
+            'averageScore': round(self.averageScore, 2),
+            'averageAgainst': round(self.averageAgainst, 2),
+            'highGame': self.highGame,
+            'highGameOpponent': self.highGameOpponent,
+            'lowGame': self.lowGame,
+            'lowGameOpponent': self.lowGameOpponent,
+            'biggestWin': self.biggestWin,
+            'biggestWinOpponent': self.biggestWinOpponent,
+            'highLoss': self.highLoss,
+            'highLossOpponent': self.highLossOpponent,
+            'lowWin': self.lowWin,
+            'lowWinOpponent': self.lowWinOpponent,
+            'gamesUnder300': self.gamesUnder300,
+            'games300to399': self.games300to399,
+            'games400to499': self.games400to499,
+            'games500to599': self.games500to599,
+            'games600plus': self.games600plus,
+        }
+
+
+class TournamentRoundResult:
+    """A single round within a tournament for a player."""
+
+    def __init__(self, data: Dict[str, Any]):
+        self.round = data.get('round')
+        self.opponent_name = data.get('opponent_name')
+        self.opponent_id = data.get('opponent_id')
+        self.opponent_rating = data.get('opponent_rating')
+        self.result = data.get('result')  # 'W', 'L', 'D', 'B'
+        self.score_for = data.get('score_for')
+        self.score_against = data.get('score_against')
+        self.player_rating_at_time = data.get('player_rating_at_time')
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'round': self.round,
+            'opponent_name': self.opponent_name,
+            'opponent_id': self.opponent_id,
+            'opponent_rating': self.opponent_rating,
+            'result': self.result,
+            'score_for': self.score_for,
+            'score_against': self.score_against,
+            'player_rating_at_time': self.player_rating_at_time,
+        }
+
+
+class TournamentResultDetailV2:
+    """A tournament entry in a player's history with per-round detail."""
+
+    def __init__(self, data: Dict[str, Any]):
+        self.playerid = data.get('playerid')
+        self.tourneyid = data.get('tourneyid')
+        self.name = data.get('name')
+        self.date = data.get('date')
+        self.division = data.get('division')
+        self.rounds: List[TournamentRoundResult] = []
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'playerid': self.playerid,
+            'tourneyid': self.tourneyid,
+            'name': self.name,
+            'date': self.date.strftime('%Y-%m-%d') if self.date else None,
+            'division': self.division,
+            'rounds': [r.to_dict() for r in self.rounds],
+        }
+
+
+class TournamentListItemV2:
+    """A tournament entry as it appears in the player endpoint's tournaments list."""
+
+    def __init__(self, data: Dict[str, Any]):
+        self.tourneyid = data.get('tourneyid')
+        self.name = data.get('name')
+        self.date = data.get('date')
+        self.division = data.get('division')
+        self.wins = data.get('wins')
+        self.losses = data.get('losses')
+        self.draws = data.get('draws', 0)
+        self.spread = data.get('spread', 0)
+        self.place = data.get('place')
+        self.endRating = data.get('end_rating')
+        self.ratingChange = data.get('rating_change')
+        self.startDeviation = data.get('start_deviation')
+        self.endDeviation = data.get('end_deviation')
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'tourneyid': self.tourneyid,
+            'name': self.name,
+            'date': self.date.strftime('%Y-%m-%d') if self.date else None,
+            'division': self.division,
+            'wins': int(self.wins) if self.wins is not None else 0,
+            'losses': int(self.losses) if self.losses is not None else 0,
+            'draws': int(self.draws) if self.draws is not None else 0,
+            'spread': int(self.spread) if self.spread is not None else 0,
+            'place': self.place,
+            'endRating': self.endRating,
+            'ratingChange': self.ratingChange,
+            'startDeviation': self.startDeviation,
+            'endDeviation': self.endDeviation,
+        }
+
+
+class PlayerResponseV2:
+    """Top-level v2 player response."""
+
+    def __init__(self, data: Dict[str, Any]):
+        self.playerid = data.get('playerid')
+        self.name = data.get('name')
+        self.country = data.get('country')
+        self.cswrating = data.get('cswrating')
+        self.photourl = data.get('photourl')
+        self.stats: Optional[PlayerStatsV2] = None
+        self.tournaments: List[TournamentListItemV2] = []
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'playerid': self.playerid,
+            'name': self.name,
+            'country': self.country,
+            'cswrating': self.cswrating,
+            'photourl': self.photourl,
+            'stats': self.stats.to_dict() if self.stats else None,
+            'tournaments': [t.to_dict() for t in self.tournaments],
         }

--- a/schema.txt
+++ b/schema.txt
@@ -1,0 +1,162 @@
+
+First, here is the database schema we will pull data from:
+
+mysql> show tables;
++--------------------+
+| Tables_in_wespa    |
++--------------------+
+| divisions          |
+| events             |
+| games              |
+| lexicons           |
+| loaded_tournaments |
+| player_alt_names   |
+| player_results     |
+| players            |
+| tournament_results |
+| tournaments        |
++--------------------+
+10 rows in set (0.00 sec)
+
+mysql> describe divisions
+    -> ;
++---------------+--------------+------+-----+---------+----------------+
+| Field         | Type         | Null | Key | Default | Extra          |
++---------------+--------------+------+-----+---------+----------------+
+| id            | int          | NO   | PRI | NULL    | auto_increment |
+| tournament_id | int          | NO   | MUL | NULL    |                |
+| name          | varchar(255) | YES  |     | NULL    |                |
+| length        | int          | YES  |     | NULL    |                |
+| number        | int          | YES  |     | NULL    |                |
++---------------+--------------+------+-----+---------+----------------+
+5 rows in set (0.04 sec)
+
+mysql> describe events;
++------------+--------------+------+-----+---------+----------------+
+| Field      | Type         | Null | Key | Default | Extra          |
++------------+--------------+------+-----+---------+----------------+
+| id         | int          | NO   | PRI | NULL    | auto_increment |
+| start_date | date         | YES  |     | NULL    |                |
+| end_date   | date         | YES  |     | NULL    |                |
+| link       | varchar(255) | YES  |     | NULL    |                |
+| sponsor    | varchar(255) | YES  |     | NULL    |                |
+| country    | varchar(3)   | YES  |     | NULL    |                |
+| location   | varchar(255) | YES  |     | NULL    |                |
++------------+--------------+------+-----+---------+----------------+
+7 rows in set (0.01 sec)
+
+mysql> describe games;
++--------------+--------------+------+-----+---------+----------------+
+| Field        | Type         | Null | Key | Default | Extra          |
++--------------+--------------+------+-----+---------+----------------+
+| id           | int          | NO   | PRI | NULL    | auto_increment |
+| division_id  | int          | NO   | MUL | NULL    |                |
+| round        | int          | YES  |     | NULL    |                |
+| lexicon_id   | int          | NO   | MUL | NULL    |                |
+| gcg_filename | varchar(255) | YES  |     | NULL    |                |
++--------------+--------------+------+-----+---------+----------------+
+5 rows in set (0.01 sec)
+
+mysql> describe lexicons;
++-------+--------------+------+-----+---------+----------------+
+| Field | Type         | Null | Key | Default | Extra          |
++-------+--------------+------+-----+---------+----------------+
+| id    | int          | NO   | PRI | NULL    | auto_increment |
+| name  | varchar(255) | YES  |     | NULL    |                |
++-------+--------------+------+-----+---------+----------------+
+2 rows in set (0.00 sec)
+
+mysql> describe loaded_tournaments;
++----------+--------------+------+-----+---------+----------------+
+| Field    | Type         | Null | Key | Default | Extra          |
++----------+--------------+------+-----+---------+----------------+
+| id       | int          | NO   | PRI | NULL    | auto_increment |
+| name     | varchar(255) | YES  |     | NULL    |                |
+| filename | varchar(255) | YES  |     | NULL    |                |
++----------+--------------+------+-----+---------+----------------+
+3 rows in set (0.00 sec)
+
+mysql> describe player_alt_names;
++-----------+--------------+------+-----+---------+----------------+
+| Field     | Type         | Null | Key | Default | Extra          |
++-----------+--------------+------+-----+---------+----------------+
+| id        | int          | NO   | PRI | NULL    | auto_increment |
+| alt_name  | varchar(255) | YES  |     | NULL    |                |
+| player_id | int          | NO   | MUL | NULL    |                |
++-----------+--------------+------+-----+---------+----------------+
+3 rows in set (0.01 sec)
+
+mysql> describe player_results;
++-----------+------+------+-----+---------+----------------+
+| Field     | Type | Null | Key | Default | Extra          |
++-----------+------+------+-----+---------+----------------+
+| id        | int  | NO   | PRI | NULL    | auto_increment |
+| player_id | int  | NO   | MUL | NULL    |                |
+| game_id   | int  | NO   | MUL | NULL    |                |
+| score     | int  | YES  |     | NULL    |                |
+| result    | int  | YES  |     | NULL    |                |
++-----------+------+------+-----+---------+----------------+
+5 rows in set (0.01 sec)
+
+mysql> describe players;
++-------------+--------------+------+-----+---------+----------------+
+| Field       | Type         | Null | Key | Default | Extra          |
++-------------+--------------+------+-----+---------+----------------+
+| id          | int          | NO   | PRI | NULL    | auto_increment |
+| name        | varchar(255) | YES  |     | NULL    |                |
+| country     | varchar(3)   | YES  |     | NULL    |                |
+| photo       | varchar(255) | YES  |     | NULL    |                |
+| suspended   | tinyint(1)   | YES  |     | NULL    |                |
+| deceased    | tinyint(1)   | YES  |     | NULL    |                |
+| current     | tinyint(1)   | YES  |     | NULL    |                |
+| provisional | tinyint(1)   | YES  |     | NULL    |                |
+| total_games | int          | YES  |     | NULL    |                |
+| last_played | date         | YES  |     | NULL    |                |
+| rating      | int          | YES  |     | NULL    |                |
++-------------+--------------+------+-----+---------+----------------+
+11 rows in set (0.01 sec)
+
+mysql> describe tournament_results;
++-------------------+--------------+------+-----+---------+----------------+
+| Field             | Type         | Null | Key | Default | Extra          |
++-------------------+--------------+------+-----+---------+----------------+
+| id                | int          | NO   | PRI | NULL    | auto_increment |
+| division_id       | int          | NO   | MUL | NULL    |                |
+| player_id         | int          | NO   | MUL | NULL    |                |
+| player_name       | varchar(255) | YES  |     | NULL    |                |
+| position          | int          | YES  |     | NULL    |                |
+| wins              | float        | YES  |     | NULL    |                |
+| losses            | float        | YES  |     | NULL    |                |
+| byes              | int          | YES  |     | NULL    |                |
+| spread            | int          | YES  |     | NULL    |                |
+| prize_money       | int          | YES  |     | NULL    |                |
+| prize_currency    | varchar(255) | YES  |     | NULL    |                |
+| prize_ech_rate    | varchar(255) | YES  |     | NULL    |                |
+| start_rating      | int          | YES  |     | NULL    |                |
+| end_rating        | int          | YES  |     | NULL    |                |
+| date              | date         | YES  |     | NULL    |                |
+| tournament_name   | varchar(255) | YES  |     | NULL    |                |
+| expected_wins     | float        | YES  |     | NULL    |                |
+| old_world_rank    | int          | YES  |     | NULL    |                |
+| new_world_rank    | int          | YES  |     | NULL    |                |
+| old_national_rank | int          | YES  |     | NULL    |                |
+| new_national_rank | int          | YES  |     | NULL    |                |
+| old_rating_dev    | int          | YES  |     | NULL    |                |
+| new_rating_dev    | int          | YES  |     | NULL    |                |
++-------------------+--------------+------+-----+---------+----------------+
+23 rows in set (0.00 sec)
+
+mysql> describe tournaments;
++------------+--------------+------+-----+---------+----------------+
+| Field      | Type         | Null | Key | Default | Extra          |
++------------+--------------+------+-----+---------+----------------+
+| id         | int          | NO   | PRI | NULL    | auto_increment |
+| event_id   | int          | NO   | MUL | NULL    |                |
+| td         | varchar(255) | YES  |     | NULL    |                |
+| start_date | date         | YES  |     | NULL    |                |
+| end_date   | date         | YES  |     | NULL    |                |
+| name       | varchar(255) | YES  |     | NULL    |                |
+| country    | varchar(3)   | YES  |     | NULL    |                |
++------------+--------------+------+-----+---------+----------------+
+7 rows in set (0.00 sec)
+

--- a/services/player_v2_queries.py
+++ b/services/player_v2_queries.py
@@ -1,0 +1,292 @@
+import logging
+from typing import List, Optional, Dict, Any, Tuple
+from services.db import execute_query, execute_query_one
+
+logger = logging.getLogger(__name__)
+
+
+def get_basic_player_v2(player_id: int) -> Optional[Dict[str, Any]]:
+    """Get basic player information.
+
+    cswrating is set to the end_rating from the player's most recent
+    tournament, falling back to the players.rating if none exists.
+    """
+    query = """
+        SELECT
+            p.id as playerid,
+            p.name,
+            p.country,
+            COALESCE(
+                (SELECT tr.end_rating FROM tournament_results tr
+                 WHERE tr.player_id = p.id AND tr.end_rating IS NOT NULL
+                 ORDER BY tr.date DESC LIMIT 1),
+                p.rating
+            ) as cswrating,
+            p.photo as photourl
+        FROM players p
+        WHERE p.id = %s
+    """
+    return execute_query_one(query, (player_id,))
+
+
+def get_player_stats_v2(player_id: int) -> Optional[Dict[str, Any]]:
+    """Compute detailed career stats for a player.
+
+    Returns a dict with all the fields needed for PlayerStatsV2, or
+    None if the player has no results.
+    """
+    # --- Aggregate stats from player_results, and fetch opponent info ---
+    # strategy: get all non-bye game results, join to find the opponent
+    # result on the same game, then aggregate in Python.
+    query = """
+        SELECT
+            pr.score,
+            pr.result,
+            g.id as game_id,
+            g.round,
+            opp_pr.score as opp_score,
+            opp_pr.player_id as opp_player_id,
+            opp_p.name as opp_name,
+            opp_p.rating as opp_rating
+        FROM player_results pr
+        JOIN games g ON pr.game_id = g.id
+        JOIN player_results opp_pr
+            ON opp_pr.game_id = g.id
+           AND opp_pr.player_id != pr.player_id
+        JOIN players opp_p ON opp_pr.player_id = opp_p.id
+        WHERE pr.player_id = %s
+          AND pr.score > 0
+        ORDER BY g.id
+    """
+    rows = execute_query(query, (player_id,))
+    if not rows:
+        return None
+
+    # Trackers for aggregations
+    total_games = 0
+    wins = 0
+    losses = 0
+    draws = 0
+    total_score = 0
+    total_against = 0
+
+    high_game = None
+    high_game_opp = None
+    low_game = None
+    low_game_opp = None
+
+    biggest_win_margin = None
+    biggest_win_opp = None
+    high_loss_score = None
+    high_loss_opp = None
+    low_win_score = None
+    low_win_opp = None
+
+    buckets = {
+        'under300': 0,
+        '300to399': 0,
+        '400to499': 0,
+        '500to599': 0,
+        '600plus': 0,
+    }
+
+    for row in rows:
+        score = row['score']
+        opp_score = row['opp_score']
+        result = row['result']
+        opp_name = row['opp_name']
+
+        # Skip byes (score == 0 already filtered above, but double-check)
+        if score is None or score == 0:
+            continue
+
+        total_games += 1
+        total_score += score
+        total_against += opp_score
+
+        if result == 1:
+            wins += 1
+        elif result == -1:
+            losses += 1
+        elif result == 0:
+            draws += 1
+
+        # High / low game
+        if high_game is None or score > high_game:
+            high_game = score
+            high_game_opp = opp_name
+        if low_game is None or score < low_game:
+            low_game = score
+            low_game_opp = opp_name
+
+        # Biggest win margin
+        if result == 1:
+            margin = score - opp_score
+            if biggest_win_margin is None or margin > biggest_win_margin:
+                biggest_win_margin = margin
+                biggest_win_opp = opp_name
+
+            # Lowest winning score
+            if low_win_score is None or score < low_win_score:
+                low_win_score = score
+                low_win_opp = opp_name
+
+        # Highest losing score
+        if result == -1:
+            if high_loss_score is None or score > high_loss_score:
+                high_loss_score = score
+                high_loss_opp = opp_name
+
+        # Scoring buckets
+        if score < 300:
+            buckets['under300'] += 1
+        elif score < 400:
+            buckets['300to399'] += 1
+        elif score < 500:
+            buckets['400to499'] += 1
+        elif score < 600:
+            buckets['500to599'] += 1
+        else:
+            buckets['600plus'] += 1
+
+    win_pct = (wins / (wins + losses + draws) * 100) if (wins + losses + draws) > 0 else 0.0
+    avg_score = total_score / total_games if total_games > 0 else 0.0
+    avg_against = total_against / total_games if total_games > 0 else 0.0
+
+    # Fetch bye count separately
+    bye_count = _get_bye_count(player_id)
+
+    return {
+        'gamesPlayed': total_games,
+        'wins': wins,
+        'losses': losses,
+        'draws': draws,
+        'byes': bye_count,
+        'winPercentage': win_pct,
+        'averageScore': avg_score,
+        'averageAgainst': avg_against,
+        'highGame': high_game,
+        'highGameOpponent': high_game_opp,
+        'lowGame': low_game,
+        'lowGameOpponent': low_game_opp,
+        'biggestWin': biggest_win_margin,
+        'biggestWinOpponent': biggest_win_opp,
+        'highLoss': high_loss_score,
+        'highLossOpponent': high_loss_opp,
+        'lowWin': low_win_score,
+        'lowWinOpponent': low_win_opp,
+        'gamesUnder300': buckets['under300'],
+        'games300to399': buckets['300to399'],
+        'games400to499': buckets['400to499'],
+        'games500to599': buckets['500to599'],
+        'games600plus': buckets['600plus'],
+    }
+
+
+def _get_bye_count(player_id: int) -> int:
+    """Count byes (result=0, score=0 or NULL)."""
+    query = """
+        SELECT COUNT(*) as cnt
+        FROM player_results
+        WHERE player_id = %s
+          AND result = 0
+          AND (score IS NULL OR score = 0)
+    """
+    row = execute_query_one(query, (player_id,))
+    return row['cnt'] if row else 0
+
+
+def get_tournament_list_v2(player_id: int) -> List[Dict[str, Any]]:
+    """Get tournament history for a player (v2 format)."""
+    query = """
+        SELECT
+            tr.id as tourneyid,
+            tr.tournament_name as name,
+            tr.date,
+            d.name as division,
+            tr.wins,
+            tr.losses,
+            COALESCE(tr.byes, 0) as draws,
+            COALESCE(tr.spread, 0) as spread,
+            tr.position as place,
+            tr.end_rating as end_rating,
+            (COALESCE(tr.end_rating, 0) - COALESCE(tr.start_rating, 0)) as rating_change,
+            tr.old_rating_dev as start_deviation,
+            tr.new_rating_dev as end_deviation
+        FROM tournament_results tr
+        JOIN divisions d ON tr.division_id = d.id
+        WHERE tr.player_id = %s
+        ORDER BY tr.date DESC
+    """
+    return execute_query(query, (player_id,))
+
+
+def get_tournament_rounds_v2(player_id: int, tourney_id: int) -> List[Dict[str, Any]]:
+    """Get per-round results for a player at a specific tournament.
+
+    Returns list of dicts with round, opponent_name, opponent_id,
+    opponent_rating, result (W/L/D/B), score_for, score_against,
+    player_rating_at_time, plus tournament-level fields.
+    """
+    # First get tournament-level info
+    t_info = execute_query_one(
+        """
+        SELECT
+            tr.id as tourney_id,
+            tr.tournament_name,
+            tr.date as tournament_date,
+            tr.start_rating,
+            d.name as division_name
+        FROM tournament_results tr
+        JOIN divisions d ON tr.division_id = d.id
+        WHERE tr.player_id = %s AND tr.id = %s
+        """,
+        (player_id, tourney_id),
+    )
+    if not t_info:
+        return []
+
+    player_start_rating = t_info['start_rating']
+
+    query = """
+        SELECT
+            g.round,
+            opp_p.name as opponent_name,
+            opp_pr.player_id as opponent_id,
+            opp_p.rating as opponent_rating,
+            pr.score as score_for,
+            opp_pr.score as score_against,
+            CASE
+                WHEN pr.result = 1 THEN 'W'
+                WHEN pr.result = -1 THEN 'L'
+                WHEN pr.result = 0 AND pr.score > 0 THEN 'D'
+                WHEN pr.result = 0 AND (pr.score IS NULL OR pr.score = 0) THEN 'B'
+                ELSE NULL
+            END as result
+        FROM player_results pr
+        JOIN games g ON pr.game_id = g.id
+        JOIN divisions d ON g.division_id = d.id
+        JOIN tournament_results tr
+            ON tr.player_id = pr.player_id
+           AND tr.division_id = d.id
+        JOIN player_results opp_pr
+            ON opp_pr.game_id = g.id
+           AND opp_pr.player_id != pr.player_id
+        JOIN players opp_p ON opp_pr.player_id = opp_p.id
+        WHERE pr.player_id = %s
+          AND tr.id = %s
+        ORDER BY g.round ASC
+    """
+    rows = execute_query(query, (player_id, tourney_id))
+
+    # Inject tournament-level fields into each row
+    base = {
+        'tournament_name': t_info['tournament_name'],
+        'tournament_date': t_info['tournament_date'],
+        'division_name': t_info['division_name'],
+        'player_rating_at_time': player_start_rating,
+    }
+    for row in rows:
+        row.update(base)
+
+    return rows


### PR DESCRIPTION
- New GET /v2/player/<id> endpoint returning player profile, career statistics (wins/losses/draws/byes, win%, averages, high/low games, scoring buckets), and tournament history with end ratings and rating deviations.
- New GET /v2/player/<id>/tournaments/<id> endpoint returning per- round results with opponent info and player rating at time.
- cswrating now sourced from the latest tournament's end_rating (falling back to players.rating).
- Tournament list includes startDeviation and endDeviation from tournament_results (old_rating_dev / new_rating_dev).
- All existing v1 endpoints remain untouched for backwards compatibility.
- Clean RESTful paths (no .php suffix) for v2 routes.
- Dockerfile: removed unnecessary gcc dependency.
- README updated with v2 documentation.