### PR TITLE
feat: add tournament and division v2 endpoints

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,1 +1,1 @@
-from api import player, players, headtohead, player_v2
+from api import player, players, headtohead, player_v2, tournament_v2, division_v2

--- a/api/division_v2.py
+++ b/api/division_v2.py
@@ -1,0 +1,41 @@
+from flask import Blueprint, jsonify
+import logging
+
+from services.tournament_v2_queries import get_tournament_v2
+from services.division_v2_queries import get_division_id, compute_division_stats
+from models.schemas import DivisionStatsResponse, DivisionStatEntry
+
+logger = logging.getLogger(__name__)
+bp = Blueprint('division_stats_v2', __name__)
+
+
+@bp.route('/v2/tournament/<int:tourney_id>/division/<int:division_index>/stats')
+def get_division_stats(tourney_id: int, division_index: int):
+    """Get detailed stats for a specific division in a tournament."""
+    try:
+        # Validate the tournament exists
+        tournament = get_tournament_v2(tourney_id)
+        if not tournament:
+            return jsonify({'error': 'Tournament not found'}), 404
+
+        # Resolve division number to internal division_id
+        division_id = get_division_id(tourney_id, division_index)
+        if not division_id:
+            return jsonify({'error': 'Division not found'}), 404
+
+        # Compute all stats
+        stats_data = compute_division_stats(division_id)
+
+        response = DivisionStatsResponse()
+        for category in ('highWin', 'highLoss', 'highSpread', 'highCombined', 'upsets'):
+            entries = stats_data.get(category, [])
+            setattr(response, category, [DivisionStatEntry(e) for e in entries])
+
+        return jsonify(response.to_dict())
+
+    except Exception as e:
+        logger.error(
+            f"Error fetching division stats for tournament {tourney_id}, "
+            f"division {division_index}: {e}"
+        )
+        return jsonify({'error': 'Internal server error'}), 500

--- a/api/tournament_v2.py
+++ b/api/tournament_v2.py
@@ -1,0 +1,83 @@
+from flask import Blueprint, jsonify
+import logging
+import re
+
+from services.tournament_v2_queries import (
+    get_tournament_v2,
+    get_divisions_for_tournament,
+    get_standings_for_division,
+)
+from services.division_v2_queries import get_division_id, get_division_ratings
+from models.schemas import (
+    TournamentResponseV2,
+    DivisionV2,
+    DivisionStandingV2,
+    DivisionRatingsResponse,
+    DivisionRatingEntry,
+)
+
+logger = logging.getLogger(__name__)
+bp = Blueprint('tournament_v2', __name__)
+
+
+@bp.route('/v2/tournament/<int:tourney_id>')
+def get_tournament(tourney_id: int):
+    """Get tournament details including all divisions and standings."""
+    try:
+        info = get_tournament_v2(tourney_id)
+        if not info:
+            return jsonify({'error': 'Tournament not found'}), 404
+
+        # Clean up the location string — remove trailing ", " if location was empty
+        location = info.get('location', '')
+        location = re.sub(r'^,\s*', '', location)
+        location = re.sub(r',\s*$', '', location)
+
+        response = TournamentResponseV2({
+            'tourneyid': info['tourneyid'],
+            'name': info['name'],
+            'date': info['date'],
+            'location': location or None,
+        })
+
+        divisions = get_divisions_for_tournament(tourney_id)
+        for div_row in divisions:
+            div = DivisionV2({
+                'division': div_row['division_number'],
+                'name': div_row['name'],
+            })
+            standings = get_standings_for_division(div_row['division_id'])
+            div.standings = [DivisionStandingV2(s) for s in standings]
+            response.divisions.append(div)
+
+        return jsonify(response.to_dict())
+
+    except Exception as e:
+        logger.error(f"Error fetching tournament {tourney_id}: {e}")
+        return jsonify({'error': 'Internal server error'}), 500
+
+
+@bp.route('/v2/tournament/<int:tourney_id>/division/<int:division_index>/ratings')
+def get_division_ratings_route(tourney_id: int, division_index: int):
+    """Get rating/rank info for all players in a division."""
+    try:
+        tournament = get_tournament_v2(tourney_id)
+        if not tournament:
+            return jsonify({'error': 'Tournament not found'}), 404
+
+        division_id = get_division_id(tourney_id, division_index)
+        if not division_id:
+            return jsonify({'error': 'Division not found'}), 404
+
+        rows = get_division_ratings(division_id)
+        response = DivisionRatingsResponse()
+        response.ratings = [DivisionRatingEntry(r) for r in rows]
+
+        return jsonify(response.to_dict())
+
+    except Exception as e:
+        logger.error(
+            f"Error fetching division ratings for tournament {tourney_id}, "
+            f"division {division_index}: {e}"
+        )
+        return jsonify({'error': 'Internal server error'}), 500

--- a/app.py
+++ b/app.py
@@ -40,11 +40,13 @@ limiter = Limiter(
 )
 
 # Register blueprints
-from api import player, players, headtohead, player_v2
+from api import player, players, headtohead, player_v2, tournament_v2, division_v2
 app.register_blueprint(player.bp)
 app.register_blueprint(players.bp)
 app.register_blueprint(headtohead.bp)
 app.register_blueprint(player_v2.bp)
+app.register_blueprint(tournament_v2.bp)
+app.register_blueprint(division_v2.bp)
 
 @app.route('/health')
 @cache.cached(timeout=60)

--- a/models/schemas.py
+++ b/models/schemas.py
@@ -296,3 +296,197 @@ class PlayerResponseV2:
             'stats': self.stats.to_dict() if self.stats else None,
             'tournaments': [t.to_dict() for t in self.tournaments],
         }
+
+
+# ---------------------------------------------------------------------------
+# Tournament v2 schemas
+# ---------------------------------------------------------------------------
+
+class DivisionStandingV2:
+    """A single player's standing within a division."""
+
+    def __init__(self, data: Dict[str, Any]):
+        self.place = data.get('place')
+        self.playerid = data.get('playerid')
+        self.name = data.get('name')
+        self.country = data.get('country')
+        self.wins = data.get('wins')
+        self.losses = data.get('losses')
+        self.byes = data.get('byes', 0)
+        self.spread = data.get('spread', 0)
+        self.startRating = data.get('start_rating')
+        self.endRating = data.get('end_rating')
+        self.ratingChange = data.get('rating_change')
+        self.startDeviation = data.get('start_deviation')
+        self.endDeviation = data.get('end_deviation')
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'place': self.place,
+            'playerid': self.playerid,
+            'name': self.name,
+            'country': self.country,
+            'wins': int(self.wins) if self.wins is not None else 0,
+            'losses': int(self.losses) if self.losses is not None else 0,
+            'byes': int(self.byes) if self.byes is not None else 0,
+            'spread': int(self.spread) if self.spread is not None else 0,
+            'startRating': self.startRating,
+            'endRating': self.endRating,
+            'ratingChange': self.ratingChange,
+            'startDeviation': self.startDeviation,
+            'endDeviation': self.endDeviation,
+        }
+
+
+class DivisionV2:
+    """A division within a tournament, with standings."""
+
+    def __init__(self, data: Dict[str, Any]):
+        self.division = data.get('division')
+        self.name = data.get('name')
+        self.standings: List[DivisionStandingV2] = []
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'division': self.division,
+            'name': self.name,
+            'standings': [s.to_dict() for s in self.standings],
+        }
+
+
+class TournamentResponseV2:
+    """Top-level v2 tournament response."""
+
+    def __init__(self, data: Dict[str, Any]):
+        self.tourneyid = data.get('tourneyid')
+        self.name = data.get('name')
+        self.date = data.get('date')
+        self.location = data.get('location')
+        self.divisions: List[DivisionV2] = []
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'tourneyid': self.tourneyid,
+            'name': self.name,
+            'date': self.date.strftime('%Y-%m-%d') if self.date else None,
+            'location': self.location,
+            'divisions': [d.to_dict() for d in self.divisions],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Division stats v2 schemas
+# ---------------------------------------------------------------------------
+
+class DivisionStatEntry:
+    """A single ranked entry in a division stats category."""
+
+    def __init__(self, data: Dict[str, Any]):
+        self.rank = data.get('rank')
+        self.player_id = data.get('player_id')
+        self.player_name = data.get('player_name')
+        # Most categories have these
+        self.score = data.get('score')
+        self.opponent_id = data.get('opponent_id')
+        self.opponent_name = data.get('opponent_name')
+        self.round = data.get('round')
+        # highSpread only
+        self.opponent_score = data.get('opponent_score')
+        self.spread = data.get('spread')
+        # highCombined only
+        self.player1_id = data.get('player1_id')
+        self.player1_name = data.get('player1_name')
+        self.player2_id = data.get('player2_id')
+        self.player2_name = data.get('player2_name')
+        self.total_score = data.get('total_score')
+        # upsets only
+        self.player_rating = data.get('player_rating')
+        self.opponent_rating = data.get('opponent_rating')
+        self.difference = data.get('difference')
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {}
+        for key in ('rank', 'player_id', 'player_name', 'score',
+                     'opponent_id', 'opponent_name', 'round',
+                     'opponent_score', 'spread',
+                     'player1_id', 'player1_name',
+                     'player2_id', 'player2_name', 'total_score',
+                     'player_rating', 'opponent_rating', 'difference'):
+            val = getattr(self, key, None)
+            if val is not None:
+                d[key] = val
+        return d
+
+
+class DivisionStatsResponse:
+    """All stats for a division: highWin, highLoss, highSpread, highCombined, upsets."""
+
+    def __init__(self):
+        self.highWin: List[DivisionStatEntry] = []
+        self.highLoss: List[DivisionStatEntry] = []
+        self.highSpread: List[DivisionStatEntry] = []
+        self.highCombined: List[DivisionStatEntry] = []
+        self.upsets: List[DivisionStatEntry] = []
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'highWin': [e.to_dict() for e in self.highWin],
+            'highLoss': [e.to_dict() for e in self.highLoss],
+            'highSpread': [e.to_dict() for e in self.highSpread],
+            'highCombined': [e.to_dict() for e in self.highCombined],
+            'upsets': [e.to_dict() for e in self.upsets],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Division ratings v2 schemas
+# ---------------------------------------------------------------------------
+
+class DivisionRatingEntry:
+    """Player rating info within a division."""
+
+    def __init__(self, data: Dict[str, Any]):
+        self.playerid = data.get('playerid')
+        self.name = data.get('name')
+        self.country = data.get('country')
+        self.expectedWins = data.get('expected_wins')
+        self.actualWins = data.get('actual_wins')
+        self.oldWorldRank = data.get('old_world_rank')
+        self.newWorldRank = data.get('new_world_rank')
+        self.oldNationRank = data.get('old_nation_rank')
+        self.newNationRank = data.get('new_nation_rank')
+        self.startRating = data.get('start_rating')
+        self.endRating = data.get('end_rating')
+        self.ratingChange = data.get('rating_change')
+        self.startDeviation = data.get('start_deviation')
+        self.endDeviation = data.get('end_deviation')
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'playerid': self.playerid,
+            'name': self.name,
+            'country': self.country,
+            'expectedWins': float(self.expectedWins) if self.expectedWins is not None else None,
+            'actualWins': self.actualWins,
+            'oldWorldRank': self.oldWorldRank,
+            'newWorldRank': self.newWorldRank,
+            'oldNationRank': self.oldNationRank,
+            'newNationRank': self.newNationRank,
+            'startRating': self.startRating,
+            'endRating': self.endRating,
+            'ratingChange': self.ratingChange,
+            'startDeviation': self.startDeviation,
+            'endDeviation': self.endDeviation,
+        }
+
+
+class DivisionRatingsResponse:
+    """All player rating info for a division."""
+
+    def __init__(self):
+        self.ratings: List[DivisionRatingEntry] = []
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'ratings': [r.to_dict() for r in self.ratings],
+        }

--- a/services/division_v2_queries.py
+++ b/services/division_v2_queries.py
@@ -1,0 +1,202 @@
+import logging
+from typing import Dict, Any, List, Optional
+from services.db import execute_query, execute_query_one
+
+logger = logging.getLogger(__name__)
+
+
+def get_division_id(tourney_id: int, division_index: int) -> Optional[int]:
+    """Resolve a tournament ID and division number to a divisions.id."""
+    row = execute_query_one(
+        """
+        SELECT d.id FROM divisions d
+        JOIN tournaments t ON d.tournament_id = t.id
+        WHERE t.id = %s AND d.number = %s
+        """,
+        (tourney_id, division_index),
+    )
+    return row['id'] if row else None
+
+
+def get_all_games_with_players(division_id: int) -> List[Dict[str, Any]]:
+    """Get every game in a division with both player results and player info."""
+    query = """
+        SELECT
+            g.id as game_id,
+            g.round,
+            pr1.player_id as p1_id,
+            p1.name as p1_name,
+            p1.rating as p1_rating,
+            pr1.score as p1_score,
+            pr1.result as p1_result,
+            pr2.player_id as p2_id,
+            p2.name as p2_name,
+            p2.rating as p2_rating,
+            pr2.score as p2_score,
+            pr2.result as p2_result
+        FROM games g
+        JOIN player_results pr1
+            ON pr1.game_id = g.id
+        JOIN player_results pr2
+            ON pr2.game_id = g.id AND pr2.player_id != pr1.player_id
+        JOIN players p1 ON pr1.player_id = p1.id
+        JOIN players p2 ON pr2.player_id = p2.id
+        WHERE g.division_id = %s
+          AND pr1.score IS NOT NULL AND pr1.score > 0
+          AND pr2.score IS NOT NULL AND pr2.score > 0
+        ORDER BY g.round ASC, g.id ASC
+    """
+    return execute_query(query, (division_id,))
+
+
+def compute_division_stats(division_id: int, top_n: int = 10) -> Dict[str, List[Dict[str, Any]]]:
+    """Compute all stats categories for a division.
+
+    Stats computed:
+      - highWin: highest winning scores
+      - highLoss: highest losing scores
+      - highSpread: biggest spreads (score - opponent_score) in wins
+      - highCombined: highest combined scores
+      - upsets: biggest rating differences where lower-rated player won
+    """
+    games = get_all_games_with_players(division_id)
+    if not games:
+        return {
+            'highWin': [],
+            'highLoss': [],
+            'highSpread': [],
+            'highCombined': [],
+            'upsets': [],
+        }
+
+    high_win = []
+    high_loss = []
+    high_spread = []
+    high_combined = []
+    upsets = []
+
+    for g in games:
+        rnd = g['round']
+        p1_id, p1_name, p1_score, p1_rating, p1_result = (
+            g['p1_id'], g['p1_name'], g['p1_score'], g['p1_rating'], g['p1_result'])
+        p2_id, p2_name, p2_score, p2_rating, p2_result = (
+            g['p2_id'], g['p2_name'], g['p2_score'], g['p2_rating'], g['p2_result'])
+
+        # highWin / highLoss
+        if p1_result == 1:
+            high_win.append({
+                'player_id': p1_id, 'player_name': p1_name,
+                'score': p1_score, 'opponent_id': p2_id,
+                'opponent_name': p2_name, 'round': rnd,
+            })
+        elif p1_result == -1:
+            high_loss.append({
+                'player_id': p1_id, 'player_name': p1_name,
+                'score': p1_score, 'opponent_id': p2_id,
+                'opponent_name': p2_name, 'round': rnd,
+            })
+
+        if p2_result == 1:
+            high_win.append({
+                'player_id': p2_id, 'player_name': p2_name,
+                'score': p2_score, 'opponent_id': p1_id,
+                'opponent_name': p1_name, 'round': rnd,
+            })
+        elif p2_result == -1:
+            high_loss.append({
+                'player_id': p2_id, 'player_name': p2_name,
+                'score': p2_score, 'opponent_id': p1_id,
+                'opponent_name': p1_name, 'round': rnd,
+            })
+
+        # highSpread (spread on winning side only)
+        if p1_result == 1:
+            spread = p1_score - p2_score
+            high_spread.append({
+                'player_id': p1_id, 'player_name': p1_name,
+                'score': p1_score, 'opponent_id': p2_id,
+                'opponent_name': p2_name, 'opponent_score': p2_score,
+                'spread': spread, 'round': rnd,
+            })
+        elif p2_result == 1:
+            spread = p2_score - p1_score
+            high_spread.append({
+                'player_id': p2_id, 'player_name': p2_name,
+                'score': p2_score, 'opponent_id': p1_id,
+                'opponent_name': p1_name, 'opponent_score': p1_score,
+                'spread': spread, 'round': rnd,
+            })
+
+        # highCombined
+        combined = p1_score + p2_score
+        high_combined.append({
+            'player1_id': p1_id, 'player1_name': p1_name,
+            'player2_id': p2_id, 'player2_name': p2_name,
+            'total_score': combined, 'round': rnd,
+        })
+
+        # Upsets: lower-rated player beats higher-rated player
+        if p1_rating is not None and p2_rating is not None:
+            if p1_result == 1 and p1_rating < p2_rating:
+                diff = p2_rating - p1_rating
+                upsets.append({
+                    'player_id': p1_id, 'player_name': p1_name,
+                    'player_rating': p1_rating,
+                    'opponent_id': p2_id, 'opponent_name': p2_name,
+                    'opponent_rating': p2_rating,
+                    'difference': diff, 'round': rnd,
+                })
+            elif p2_result == 1 and p2_rating < p1_rating:
+                diff = p1_rating - p2_rating
+                upsets.append({
+                    'player_id': p2_id, 'player_name': p2_name,
+                    'player_rating': p2_rating,
+                    'opponent_id': p1_id, 'opponent_name': p1_name,
+                    'opponent_rating': p1_rating,
+                    'difference': diff, 'round': rnd,
+                })
+
+    # Sort each category and take top_n, then assign ranks
+    def sort_and_rank(items, sort_key, reverse=True):
+        items_sorted = sorted(items, key=sort_key, reverse=reverse)[:top_n]
+        for i, item in enumerate(items_sorted):
+            item['rank'] = i + 1
+        return items_sorted
+
+    return {
+        'highWin': sort_and_rank(high_win, lambda x: x['score']),
+        'highLoss': sort_and_rank(high_loss, lambda x: x['score']),
+        'highSpread': sort_and_rank(high_spread, lambda x: x['spread']),
+        'highCombined': sort_and_rank(high_combined, lambda x: x['total_score']),
+        'upsets': sort_and_rank(upsets, lambda x: x['difference']),
+    }
+
+
+def get_division_ratings(division_id: int) -> List[Dict[str, Any]]:
+    """Get rating/rank info for every player in a division, ordered by position.
+
+    actualWins = wins + (byes as draws counted as 0.5)
+    ratingChange = endRating - startRating
+    """
+    query = """
+        SELECT
+            p.id as playerid,
+            p.name,
+            p.country,
+            tr.expected_wins as expected_wins,
+            (COALESCE(tr.wins, 0) + (COALESCE(tr.byes, 0) * 0.5)) as actual_wins,
+            tr.old_world_rank as old_world_rank,
+            tr.new_world_rank as new_world_rank,
+            tr.old_national_rank as old_nation_rank,
+            tr.new_national_rank as new_nation_rank,
+            tr.start_rating,
+            tr.end_rating,
+            (COALESCE(tr.end_rating, 0) - COALESCE(tr.start_rating, 0)) as rating_change,
+            tr.old_rating_dev as start_deviation,
+            tr.new_rating_dev as end_deviation
+        FROM tournament_results tr
+        JOIN players p ON tr.player_id = p.id
+        WHERE tr.division_id = %s
+        ORDER BY tr.position ASC
+    """
+    return execute_query(query, (division_id,))

--- a/services/tournament_v2_queries.py
+++ b/services/tournament_v2_queries.py
@@ -1,0 +1,67 @@
+import logging
+from typing import List, Optional, Dict, Any
+from services.db import execute_query, execute_query_one
+
+logger = logging.getLogger(__name__)
+
+
+def get_tournament_v2(tourney_id: int) -> Optional[Dict[str, Any]]:
+    """Get tournament-level info: name, date, location.
+
+    The tournament id in the DB is the `tournaments.id` column.
+    Location comes from the associated event (events.location, events.country).
+    Date is the tournament start_date.
+    """
+    query = """
+        SELECT
+            t.id as tourneyid,
+            t.name,
+            t.start_date as date,
+            CONCAT(COALESCE(e.location, ''), ', ', COALESCE(e.country, e.country, '')) as location
+        FROM tournaments t
+        LEFT JOIN events e ON t.event_id = e.id
+        WHERE t.id = %s
+    """
+    return execute_query_one(query, (tourney_id,))
+
+
+def get_divisions_for_tournament(tourney_id: int) -> List[Dict[str, Any]]:
+    """Get all divisions belonging to a tournament."""
+    query = """
+        SELECT
+            d.id as division_id,
+            d.name,
+            d.number as division_number
+        FROM divisions d
+        WHERE d.tournament_id = %s
+        ORDER BY d.number ASC
+    """
+    return execute_query(query, (tourney_id,))
+
+
+def get_standings_for_division(division_id: int) -> List[Dict[str, Any]]:
+    """Get all player standings for a given division, ordered by position.
+
+    Uses the tournament_results table joined with players for name/country.
+    """
+    query = """
+        SELECT
+            tr.position as place,
+            p.id as playerid,
+            p.name,
+            p.country,
+            tr.wins,
+            tr.losses,
+            COALESCE(tr.byes, 0) as byes,
+            COALESCE(tr.spread, 0) as spread,
+            tr.start_rating,
+            tr.end_rating,
+            (COALESCE(tr.end_rating, 0) - COALESCE(tr.start_rating, 0)) as rating_change,
+            tr.old_rating_dev as start_deviation,
+            tr.new_rating_dev as end_deviation
+        FROM tournament_results tr
+        JOIN players p ON tr.player_id = p.id
+        WHERE tr.division_id = %s
+        ORDER BY tr.position ASC
+    """
+    return execute_query(query, (division_id,))


### PR DESCRIPTION
- GET /v2/tournament/<id> — tournament details with all divisions, standings, and player info (name, country, ratings, deviations).
- GET /v2/tournament/<id>/division/<index>/stats — division-level stats: highWin, highLoss, highSpread, highCombined, and upsets (biggest rating differences where lower-rated player won).
- GET /v2/tournament/<id>/division/<index>/ratings — per-player rating info: start/end ratings, rating change, deviations, world and national ranks, expected vs actual wins (includes draws as 0.5). All numeric fields are Numbers; rank fields may be null.