### PR TITLE
Added endpoints for full rankings page

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,1 +1,2 @@
 from api import player, players, headtohead, player_v2, tournament_v2, division_v2, tournament_search
+from api import rankings_v2

--- a/api/rankings_v2.py
+++ b/api/rankings_v2.py
@@ -1,0 +1,55 @@
+from flask import Blueprint, request, jsonify
+import logging
+
+from services.rankings_queries import get_rankings_page, get_latest_tournament
+
+logger = logging.getLogger(__name__)
+bp = Blueprint('rankings_v2', __name__)
+
+
+@bp.route('/v2/rankings')
+def rankings():
+    """Return a paginated rankings page, sorted by rating descending.
+
+    Query parameters:
+        page     - Page number (1-based, default 1)
+        per_page - Players per page (default 50, max 100)
+        search   - Optional player name to jump to their page
+    """
+    try:
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 50, type=int)
+        search = request.args.get('search', '').strip() or None
+
+        if page < 1:
+            page = 1
+        if per_page < 1:
+            per_page = 50
+        if per_page > 100:
+            per_page = 100
+
+        result = get_rankings_page(
+            page=page,
+            per_page=per_page,
+            search=search,
+        )
+
+        return jsonify(result)
+
+    except Exception as e:
+        logger.error(f"Error fetching rankings: {e}")
+        return jsonify({'error': 'Internal server error'}), 500
+
+
+@bp.route('/v2/rankings/latest-tournament')
+def latest_tournament():
+    """Return the name and date of the most recent tournament."""
+    try:
+        result = get_latest_tournament()
+        if not result:
+            return jsonify({'error': 'No tournaments found'}), 404
+        return jsonify(result)
+
+    except Exception as e:
+        logger.error(f"Error fetching latest tournament: {e}")
+        return jsonify({'error': 'Internal server error'}), 500

--- a/app.py
+++ b/app.py
@@ -49,6 +49,9 @@ app.register_blueprint(tournament_v2.bp)
 app.register_blueprint(division_v2.bp)
 app.register_blueprint(tournament_search.bp)
 
+from api import rankings_v2
+app.register_blueprint(rankings_v2.bp)
+
 @app.route('/health')
 @cache.cached(timeout=60)
 @limiter.exempt

--- a/services/rankings_queries.py
+++ b/services/rankings_queries.py
@@ -1,0 +1,110 @@
+import logging
+from typing import List, Dict, Any, Optional
+from services.db import execute_query, execute_query_one
+
+logger = logging.getLogger(__name__)
+
+
+def get_rankings_page(
+    page: int = 1,
+    per_page: int = 50,
+    search: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Get a paginated page of players sorted by rating descending.
+
+    If ``search`` is provided, the player's rank is computed and the page
+    containing them is returned instead of page 1.
+    """
+    if search:
+        # Find the matching player(s) to determine which page to show
+        match_query = """
+            SELECT p.id, p.rating
+            FROM players p
+            LEFT JOIN player_alt_names pan ON p.id = pan.player_id
+            WHERE LOWER(p.name) LIKE LOWER(%s)
+               OR LOWER(pan.alt_name) LIKE LOWER(%s)
+            ORDER BY p.rating DESC
+            LIMIT 1
+        """
+        pattern = f"%{search}%"
+        match = execute_query_one(match_query, (pattern, pattern))
+
+        if match and match.get('rating') is not None:
+            # Count how many players have a higher rating
+            count_query = """
+                SELECT COUNT(*) AS higher
+                FROM players
+                WHERE rating > %s AND rating IS NOT NULL
+            """
+            count_result = execute_query_one(count_query, (match['rating'],))
+            higher = count_result['higher'] if count_result else 0
+
+            # Compute rank (1-based) and derive page
+            rank = higher + 1
+            page = max(1, (rank - 1) // per_page + 1)
+
+    offset = (page - 1) * per_page
+
+    # Get total count of rated players
+    total_result = execute_query_one(
+        "SELECT COUNT(*) AS cnt FROM players WHERE rating IS NOT NULL"
+    )
+    total = total_result['cnt'] if total_result else 0
+    total_pages = max(1, (total + per_page - 1) // per_page)
+
+    # Fetch the page of players
+    query = """
+        SELECT
+            p.id AS playerid,
+            p.name,
+            p.country,
+            p.rating,
+            COALESCE(p.total_games, 0) AS total_games,
+            p.last_played
+        FROM players p
+        WHERE p.rating IS NOT NULL
+        ORDER BY p.rating DESC
+        LIMIT %s OFFSET %s
+    """
+    rows = execute_query(query, (per_page, offset))
+
+    players = []
+    base_rank = offset + 1
+    for i, row in enumerate(rows):
+        players.append({
+            'rank': base_rank + i,
+            'playerid': row['playerid'],
+            'name': row['name'],
+            'country': row['country'],
+            'rating': row['rating'],
+            'total_games': row['total_games'],
+            'last_played': row['last_played'].strftime('%Y-%m-%d')
+                        if row.get('last_played') else None,
+        })
+
+    return {
+        'page': page,
+        'per_page': per_page,
+        'total': total,
+        'total_pages': total_pages,
+        'players': players,
+    }
+
+
+def get_latest_tournament() -> Optional[Dict[str, Any]]:
+    """Get the name and end date of the most recent tournament."""
+    query = """
+        SELECT name, end_date AS date
+        FROM tournaments
+        ORDER BY end_date DESC
+        LIMIT 1
+    """
+    row = execute_query_one(query)
+    if not row:
+        return None
+
+    return {
+        'name': row['name'],
+        'date': row['date'].strftime('%Y-%m-%d')
+                if row.get('date') else None,
+    }


### PR DESCRIPTION
New endpoints:
GET /v2/rankings?page=1&per_page=50&search=...

- Returns paginated players sorted by rating descending
- When search is provided, computes the correct page for the first matching player and returns that page
- Response includes page, per_page, total, total_pages, and players[] with rank, playerid, name, country, rating, total_games, last_played

GET /v2/rankings/latest-tournament

- Returns { "name": "...", "date": "..." } for the most recent tournament by end_date