### PR TITLE
feat: add total_players to /v2/tournament/{id} response

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Returns tournament-level info along with all divisions and their full standings.
   "name": "UK Open - Final Fling",
   "date": "2026-01-10",
   "location": "Birmingham, England",
+  "total_players": 45,
   "divisions": [
     {
       "division": 1,

--- a/api/tournament_v2.py
+++ b/api/tournament_v2.py
@@ -50,6 +50,11 @@ def get_tournament(tourney_id: int):
             div.standings = [DivisionStandingV2(s) for s in standings]
             response.divisions.append(div)
 
+        # Count total players across all divisions
+        response.total_players = sum(
+            len(div.standings) for div in response.divisions
+        )
+
         return jsonify(response.to_dict())
 
     except Exception as e:

--- a/models/schemas.py
+++ b/models/schemas.py
@@ -370,6 +370,7 @@ class TournamentResponseV2:
         self.name = data.get('name')
         self.date = data.get('date')
         self.location = data.get('location')
+        self.total_players = 0
         self.divisions: List[DivisionV2] = []
 
     def to_dict(self) -> Dict[str, Any]:
@@ -378,6 +379,7 @@ class TournamentResponseV2:
             'name': self.name,
             'date': self.date.strftime('%Y-%m-%d') if self.date else None,
             'location': self.location,
+            'total_players': self.total_players,
             'divisions': [d.to_dict() for d in self.divisions],
         }
 


### PR DESCRIPTION
- Add total_players field to TournamentResponseV2 schema
- Compute total_players by summing standings across all divisions
- Update README.md with new field in response example